### PR TITLE
Small change to permit non-activerecord models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (3.0.3)
+      activesupport (= 3.0.3)
+      builder (~> 2.1.2)
+      i18n (~> 0.4)
+    activerecord (3.0.3)
+      activemodel (= 3.0.3)
+      activesupport (= 3.0.3)
+      arel (~> 2.0.2)
+      tzinfo (~> 0.3.23)
+    activesupport (3.0.3)
+    arel (2.0.7)
+    builder (2.1.2)
+    diff-lcs (1.1.2)
+    i18n (0.5.0)
+    rspec (2.4.0)
+      rspec-core (~> 2.4.0)
+      rspec-expectations (~> 2.4.0)
+      rspec-mocks (~> 2.4.0)
+    rspec-core (2.4.0)
+    rspec-expectations (2.4.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.4.0)
+    sqlite3 (1.3.3)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
+    tzinfo (0.3.24)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord
+  rspec
+  sqlite3-ruby

--- a/lib/accept_values_for.rb
+++ b/lib/accept_values_for.rb
@@ -23,11 +23,6 @@ if defined?(ActiveModel)
     AcceptValuesFor.new(attribute, *values)
   end
   
-  if defined?(ActiveRecord)
-    @error_class = ActiveRecord::Errors
-  else
-    @error_class = ActiveModel::Errors
-  end
   
 end
 
@@ -36,6 +31,12 @@ class AcceptValuesFor  #:nodoc:
   def initialize(attribute, *values)
     @attribute = attribute
     @values = values
+
+    if defined?(ActiveRecord)
+      @error_class = ActiveRecord::Errors
+    else
+      @error_class = ActiveModel::Errors
+    end
   end
 
   def matches?(model)


### PR DESCRIPTION
Hola,
     MongoId gem uses activemodel validations, which makes your gem worthwhile.  But it's not an activerecord.  I didn't test whether this stuff still works with activerecord, since I was only concerned with my Mongo stuff.  Hopefully this change will work all around.

cheers
