### PR TITLE
Matching in accept_values_for should not be destructive

### DIFF
--- a/lib/accept_values_for.rb
+++ b/lib/accept_values_for.rb
@@ -38,7 +38,7 @@ class AcceptValuesFor  #:nodoc:
     @model = model
     return false unless model.class.included_modules.include?(ActiveModel::Validations)
     @values.each do |value|
-      model.send("#{@attribute}=", value)
+      model.stub!(:"#{@attribute}").and_return(value)
       model.valid?
       unless model.errors[@attribute].to_a.empty?
         @failed_value = value
@@ -52,7 +52,7 @@ class AcceptValuesFor  #:nodoc:
     @model = model
     return false unless model.class.included_modules.include?(ActiveModel::Validations)
     @values.each do |value|
-      model.send("#{@attribute}=", value)
+      model.stub!(:"#{@attribute}").and_return(value)
       model.valid?
       if model.errors[@attribute].to_a.empty?
         @failed_value = value


### PR DESCRIPTION
I've had a problem with destructive behavior of accept_values_for. I use Ruby 1.9.2, RSpec 2.5, FactoryGirl 2.0.0.beta2, Rails 3.0.5 and Accept_values_for 0.4.2.

Example of my spec:

```
before :all do
  @user = Factory.build(:user)
end

subject { @user }
it { should_not accept_values_for(:email, 'invalid', 'a@b', 'john@.com', '', '  ', nil) }
```

Output:

```
Before:
#<User id: nil, email: "my@mail.com", first_name: "John", last_name: "Sheppard">
    should not accept values "", "  ", nil for :first_name attribute
After:
#<User id: nil, email: "my@mail.com", first_name: nil, last_name: "Sheppard">
```

I think it's not good idea rewriting anything in matching object. It's suitable to use stubbing. I must say I don't know why your current solution behaves destructive. I don't have a deep knowledge of RSpec.
