### PR TITLE
Support Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
   - 2.5.1
 gemfile:
   - gemfiles/activemodel_4_2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ gemfile:
   - gemfiles/activemodel_4_2.gemfile
   - gemfiles/activemodel_5_0.gemfile
   - gemfiles/activemodel_5_1.gemfile
+  - gemfiles/activemodel_5_2.gemfile
 matrix:
   exclude:
     - gemfile: gemfiles/activemodel_5_0.gemfile
       rvm: 2.1.10
     - gemfile: gemfiles/activemodel_5_1.gemfile
+      rvm: 2.1.10
+    - gemfile: gemfiles/activemodel_5_2.gemfile
       rvm: 2.1.10
   allow_failures:
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.1
 gemfile:
   - gemfiles/activemodel_4_2.gemfile
   - gemfiles/activemodel_5_0.gemfile

--- a/accept_values_for.gemspec
+++ b/accept_values_for.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files      = `git ls-files -z`.split("\x0")
   spec.test_files = spec.files.grep(/^spec/)
 
-  spec.add_dependency "activemodel", ">= 4.2", "< 5.2"
+  spec.add_dependency "activemodel", ">= 4.2", "< 6.0"
   spec.add_dependency "rspec", ">= 2.0", "< 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/gemfiles/activemodel_5_2.gemfile
+++ b/gemfiles/activemodel_5_2.gemfile
@@ -6,6 +6,6 @@ gem "activemodel", "~> 5.2.0"
 
 group :test do
   gem "activerecord", "~> 5.2.0", :require => "active_record"
-  gem "rspec", "~> 3.5"
+  gem "rspec", "~> 3.7"
   gem "sqlite3-ruby", "~> 1.3"
 end

--- a/gemfiles/activemodel_5_2.gemfile
+++ b/gemfiles/activemodel_5_2.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec :path => ".."
+
+gem "activemodel", "~> 5.2.0"
+
+group :test do
+  gem "activerecord", "~> 5.2.0", :require => "active_record"
+  gem "rspec", "~> 3.5"
+  gem "sqlite3-ruby", "~> 1.3"
+end


### PR DESCRIPTION
Rails 5.2 is out...

- Loosen the required active-support version requirements (< 6.0)
- Add activemodel_5_2.gemfile and include it as part of the build matrix
- Include ruby 2.5.1 to the build matrix
- Use the latest ruby version in each release
- Use the latest rspec for the rails 5.2 builds